### PR TITLE
docs(adr): scaffold ADRs and record tooling decisions (#30)

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# NNNN. Short title of the decision
+
+- **Status**: Proposed | Accepted | Deprecated | Superseded by [NNNN](NNNN-…)
+- **Date**: YYYY-MM-DD
+- **Deciders**: @handle, @handle
+
+## Context
+
+What is the issue we're facing? What constraints apply (technical,
+organizational, legal)? Keep this section factual; save opinions for
+*Decision*.
+
+## Decision
+
+What did we decide to do? Use active voice and be specific.
+
+## Consequences
+
+What becomes easier as a result of this decision? What becomes harder?
+What follow-up work is implied?
+
+## Alternatives considered
+
+Brief notes on options that were rejected and why.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,39 @@
+# 0001. Record architecture decisions
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+- **Deciders**: @karlgroves
+
+## Context
+
+Issue [#30](https://github.com/karlgroves/openai-content-moderator/issues/30)
+proposes adopting a standardized tooling stack. Its ground rules require
+that when a proposed tool overlaps with something already in use, we
+either keep the existing tool or document the swap as an ADR. Without a
+record, those decisions live only in PR descriptions and commit
+messages, which are hard to discover months later.
+
+## Decision
+
+We will record significant, cross-cutting decisions as ADRs under
+`docs/adr/`, one file per decision, using the template at
+`0000-template.md`. ADRs are additive and immutable: when a decision
+changes, we write a new ADR that supersedes the old one rather than
+editing history.
+
+Scope: decisions about tooling, architecture, process, and
+dependencies. *Not* bug fixes, day-to-day implementation, or code style.
+
+## Consequences
+
+- Future contributors can answer "why is it like this?" without
+  archaeology across PRs and chat.
+- Small upfront cost (one short markdown file per decision).
+- Requires discipline — decisions not written down still don't exist.
+
+## Alternatives considered
+
+- **Wiki / Confluence**: rejected; the project's ground rules forbid
+  external dashboards and accounts. ADRs live alongside the code.
+- **Comments in CLAUDE.md**: rejected; CLAUDE.md should stay concise and
+  instructional. ADRs are narrative and historical.

--- a/docs/adr/0002-keep-jest-as-test-runner.md
+++ b/docs/adr/0002-keep-jest-as-test-runner.md
@@ -1,0 +1,37 @@
+# 0002. Keep Jest as the test runner
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+- **Deciders**: @karlgroves
+
+## Context
+
+Issue #30 proposes Vitest as the standard test runner. This project
+already uses Jest + Supertest with a full suite of unit and integration
+tests (85 tests passing as of Phase 1), plus `nock` for HTTP mocking
+and `@types/jest` for editor completions.
+
+Per the issue's ground rules, we do not replace tools that work unless
+there is a demonstrable quality, performance, or maintenance win.
+
+## Decision
+
+Keep Jest. Do not migrate to Vitest.
+
+## Consequences
+
+- No migration cost, no churn in test files, no temporary loss of
+  coverage during a rewrite.
+- We forgo Vitest's faster startup and native ESM support. Neither is a
+  live pain point in this repo.
+- Jest's CJS-first model aligns with the project's CommonJS source.
+- If the project adopts ESM or TypeScript in the future, revisit this
+  decision.
+
+## Alternatives considered
+
+- **Vitest**: faster, modern, good defaults. Rejected because the
+  project runs plain CJS JavaScript where Jest is the established
+  solution, and the migration cost buys us nothing today.
+- **Node's built-in test runner**: not feature-complete for our needs
+  (no supertest integration story, weaker mocking).

--- a/docs/adr/0003-plain-javascript-not-typescript.md
+++ b/docs/adr/0003-plain-javascript-not-typescript.md
@@ -1,0 +1,42 @@
+# 0003. Plain JavaScript, not TypeScript
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+- **Deciders**: @karlgroves
+
+## Context
+
+Issue #30 devotes significant space to a TypeScript setup: strict
+`tsconfig.json`, `ts-reset`, `@typescript-eslint` at
+`strict-type-checked`, TSDoc-enforced documentation, and a build step
+via `tsup`/`tsc`.
+
+This project is a small Express middleware API (under 400 lines of
+application code across `index.js`, four middleware files, and one
+route file). It runs as a Node.js process and deploys to AWS Lambda via
+Serverless Framework. There is no frontend.
+
+## Decision
+
+Stay on plain JavaScript (CommonJS). Do not adopt TypeScript for this
+project at this time.
+
+## Consequences
+
+- No build step; `node index.js` runs the source directly. Lambda
+  deployment remains trivial.
+- JSDoc remains the only option for type hints; we lean on
+  `eslint-plugin-jsdoc` at warn level.
+- We forgo compile-time type safety. The surface area is small enough
+  that tests cover the risk adequately.
+- TypeScript-specific items from #30 (`ts-reset`,
+  `@typescript-eslint/*`, `verbatimModuleSyntax`, etc.) are out of
+  scope indefinitely.
+
+## Alternatives considered
+
+- **Full TS migration**: high cost, low payoff at current scale.
+- **JSDoc + `checkJs` in a tsconfig.json**: lighter than full TS but
+  still requires a tsconfig and editor setup. Deferred — revisit if the
+  codebase grows past roughly 2-3k lines or gains non-trivial typed
+  contracts.

--- a/docs/adr/0004-best-effort-security-cli-wrappers.md
+++ b/docs/adr/0004-best-effort-security-cli-wrappers.md
@@ -1,0 +1,55 @@
+# 0004. Best-effort wrappers for external security CLIs
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+- **Deciders**: @karlgroves
+
+## Context
+
+Phase 2 of issue #30 added npm scripts for `osv-scanner`, `semgrep`,
+and `gitleaks`. These are external binaries (Rust, Python, Go) not
+installable via npm. A new contributor running `npm install` followed
+by any of the `security:*` scripts would hit an immediate "command not
+found" failure unless they had installed each tool first.
+
+We want the security scripts to be useful when the binaries are
+present, without turning "missing binary" into a hard blocker for
+everyday work.
+
+## Decision
+
+Wrap each external-binary security script in `scripts/maybe-run.sh`.
+The wrapper:
+
+- Runs the tool normally when it is installed, forwarding its exit
+  code (so real findings still fail the script).
+- Prints an install hint and exits 0 when the binary is missing.
+
+The wrapper applies to `security:osv`, `security:semgrep`, and
+`security:secrets`. License checking (`security:licenses`) uses an npm
+package and does not need the wrapper.
+
+The pre-commit hook already uses the same best-effort pattern for
+`gitleaks`.
+
+## Consequences
+
+- Zero-friction onboarding: `npm install` succeeds, `npm run security:all`
+  succeeds (degraded) on a machine without any of the external tools.
+- CI jobs that need a hard gate must explicitly install the binaries
+  before running the scripts. Best-effort behavior is a local-dev
+  convenience, not a substitute for enforced CI.
+- If a developer *thinks* they are running a security scan but the
+  binary is silently missing, they get the install hint — not a silent
+  pass. The hint is easy to miss in long output; documentation
+  (README + this ADR) has to carry the load.
+
+## Alternatives considered
+
+- **Hard-fail on missing binary**: clearer semantics, worse DX. Most
+  day-to-day work doesn't need every scanner, and new contributors
+  shouldn't be forced to install four CLIs before running tests.
+- **Ship Docker images with all tools preinstalled**: heavier than this
+  project warrants today.
+- **Install all tools via `postinstall`**: not portable (each binary
+  has a different install mechanism), and surprises users.

--- a/docs/adr/0005-new-eslint-rules-start-at-warn.md
+++ b/docs/adr/0005-new-eslint-rules-start-at-warn.md
@@ -1,0 +1,48 @@
+# 0005. New ESLint rules start at `warn` level
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+- **Deciders**: @karlgroves
+
+## Context
+
+Phase 1 of issue #30 added six new ESLint plugins: `security`,
+`sonarjs`, `n`, `unicorn`, `no-secrets`, and `jsdoc`. The issue's
+recommended config sets most of these to `error` with no escape hatch.
+
+Flipping all of them to `error` in a single PR on an existing codebase
+produces a wall of failures unrelated to the PR's intent, blocks
+unrelated work, and invites mass `eslint-disable` comments that defeat
+the point. It also makes review harder, because the diff mixes
+mechanical fixes with the tooling change itself.
+
+## Decision
+
+New ESLint plugins introduced by Phase 1 default to `warn`. We tighten
+specific rules to `error` in focused follow-up PRs, one plugin (or one
+rule family) at a time, with the accompanying code fixes in the same
+PR.
+
+The existing strict rules (`no-eval`, `prefer-const`, `no-var`,
+`eqeqeq`, `curly`) stay at `error`.
+
+## Consequences
+
+- Phase 1 merges without requiring codebase-wide fixes.
+- `eslint .` now prints ~15 warnings on the existing codebase. These
+  should be read as a backlog, not as ignorable noise.
+- Risk: warnings are easy to tolerate indefinitely. Mitigate by (a)
+  treating each new plugin's warn-to-error promotion as a tracked
+  follow-up, and (b) keeping `--max-warnings=0` out of the
+  `lint-staged` command until we're ready to enforce.
+- If the backlog grows without promotion, revisit — we may need to
+  decide to either enforce or remove the plugin.
+
+## Alternatives considered
+
+- **All rules as `error`, fix everything in Phase 1**: blocks Phase 1
+  on unrelated refactoring, bloats the diff.
+- **All rules as `off`, enable one at a time**: hides actionable
+  warnings from developers; defeats the "visible backlog" goal.
+- **Keep the issue's recommended `error` levels, but broadly disable
+  offending files**: pollutes the code with eslint-disable comments.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) — short
+documents capturing a single significant decision along with the context
+and consequences. They exist so that future contributors (human or
+agent) can understand *why* a choice was made, not just *what* the code
+does today.
+
+## Format
+
+We use a compact [MADR](https://adr.github.io/madr/)-style template. See
+`0000-template.md` for the starting point.
+
+## Index
+
+| # | Title | Status |
+| --- | --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-keep-jest-as-test-runner.md) | Keep Jest as the test runner | Accepted |
+| [0003](0003-plain-javascript-not-typescript.md) | Plain JavaScript, not TypeScript | Accepted |
+| [0004](0004-best-effort-security-cli-wrappers.md) | Best-effort wrappers for external security CLIs | Accepted |
+| [0005](0005-new-eslint-rules-start-at-warn.md) | New ESLint rules start at `warn` level | Accepted |
+
+## Creating a new ADR
+
+1. Copy `0000-template.md` to `NNNN-short-title.md`, using the next
+   available number.
+2. Fill it in. Keep it short — one decision per file.
+3. Add a row to the index above.
+4. Open a PR.
+
+Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by <id>`.


### PR DESCRIPTION
Re-opened replacement for #34 (auto-closed during the stacked-merge of #32). Content unchanged. Review comments and follow-up issue #40 are on #34. Addresses Phase 3 of #30; now targets `develop`.