### PR TITLE
fix(husky): preserve lint-staged exit status in pre-commit (#38)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 npx lint-staged
+LINT_STATUS=$?
 
 # Gitleaks: best-effort secret scanning. Install via `brew install gitleaks`
 # (or a release binary) to enable. Hook passes silently if not installed.
@@ -7,3 +8,7 @@ if command -v gitleaks >/dev/null 2>&1; then
 else
   echo "[hint] gitleaks not installed — skipping secret scan. Install: brew install gitleaks"
 fi
+
+# Preserve lint-staged's exit status: the gitleaks if/else above both exit 0,
+# which would otherwise mask ESLint/Prettier failures and let a bad commit pass.
+exit $LINT_STATUS


### PR DESCRIPTION
Fixes the High-priority bug from review of #32: `.husky/pre-commit` ran `npx lint-staged` but ended on a gitleaks `if/else` (both branches exit 0), so a commit with ESLint/Prettier errors proceeded unblocked. This captures lint-staged's exit code and exits with it.

Closes #38

---
_Part of a stacked series — merge in order: **#38** → #39 → #40 → #41 → #37._
