### PR TITLE
chore(engines): tighten node floor to >=20.5.0 (#39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.5.0"
   },
   "dependencies": {
     "body-parser": "^2.2.2",


### PR DESCRIPTION
`npm-run-all2@8` (added in Phase 2) declares `node: ^20.5.0 || >=22.0.0`, but `engines.node` was `>=20.0.0`. With `engine-strict=true` (Phase 1), a clean `npm install` on Node 20.0–20.4 hard-fails with a confusing transitive engine error. Raises the floor to match. `.nvmrc`/`.node-version` pin major `20` (latest patch), already satisfying the floor, so they're unchanged.

Closes #39

---
_Stacked on **#38**. Merge order: #38 → **#39** → #40 → #41 → #37._
