### PR TITLE
docs(adr): line count, tool languages, status convention (#40)

### DIFF
--- a/docs/adr/0003-plain-javascript-not-typescript.md
+++ b/docs/adr/0003-plain-javascript-not-typescript.md
@@ -11,10 +11,11 @@ Issue #30 devotes significant space to a TypeScript setup: strict
 `strict-type-checked`, TSDoc-enforced documentation, and a build step
 via `tsup`/`tsc`.
 
-This project is a small Express middleware API (under 400 lines of
+This project is a small Express middleware API (roughly 440 lines of
 application code across `index.js`, four middleware files, and one
-route file). It runs as a Node.js process and deploys to AWS Lambda via
-Serverless Framework. There is no frontend.
+route file — about 490 including `config/index.js`). It runs as a
+Node.js process and deploys to AWS Lambda via Serverless Framework.
+There is no frontend.
 
 ## Decision
 

--- a/docs/adr/0004-best-effort-security-cli-wrappers.md
+++ b/docs/adr/0004-best-effort-security-cli-wrappers.md
@@ -7,7 +7,7 @@
 ## Context
 
 Phase 2 of issue #30 added npm scripts for `osv-scanner`, `semgrep`,
-and `gitleaks`. These are external binaries (Rust, Python, Go) not
+and `gitleaks`. These are external binaries (Go, Python) not
 installable via npm. A new contributor running `npm install` followed
 by any of the `security:*` scripts would hit an immediate "command not
 found" failure unless they had installed each tool first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,13 @@ We use a compact [MADR](https://adr.github.io/madr/)-style template. See
 4. Open a PR.
 
 Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by <id>`.
+
+## Status convention
+
+An ADR is authored as `Proposed` while it lives on a feature branch and
+is under review. It is flipped to `Accepted` in the same PR once the
+decision is ratified and merged to `develop`. In other words, an ADR on
+`main`/`develop` reflects a ratified decision, so `Accepted` is the
+expected steady state for merged records. Use `Deprecated` or
+`Superseded by <id>` when a later decision overrides it; never edit a
+merged ADR's decision in place.


### PR DESCRIPTION
Docs-only corrections to permanent ADR records (from review of #34):

- **0003** — "under 400 lines" understated the app code (~440 lines across `index.js` + 4 middleware + 1 route, ~490 with config). Corrected.
- **0004** — "(Rust, Python, Go)" was wrong: `osv-scanner`/`gitleaks` are Go, `semgrep` is Python, no Rust binary. Now "(Go, Python)".
- **README** — documents the Proposed-on-branch / Accepted-on-merge status convention.

Closes #40

---
_Stacked on #39. Merge order: #38 → #39 → **#40** → #41 → #37._
