### PR TITLE
chore(tooling): maybe-run hardening, license trim, override pin, docs (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## Unreleased
+
+### Security
+
+- Pin `fast-xml-parser` to `5.7.1` via npm `overrides` to close
+  GHSA-gh4j-gqv2-49f6 in the transitive dependency tree.
+
 ## 1.0.0 (2026-02-01)
 
 Initial release.

--- a/middleware/perspective.js
+++ b/middleware/perspective.js
@@ -1,7 +1,11 @@
 const config = require('../config');
 
-// Lookup table built once so we can use Map.get() for attribute config
-// instead of a computed property access on the plain config object.
+// Lookup table built once at module load so we can use Map.get() for attribute
+// config instead of a computed property access on the plain config object.
+// NOTE: because this runs once when the module is first required, a test that
+// mutates `config.googlePerspective.attributes` after import will NOT see the
+// change reflected here — reset the module registry (e.g. jest.resetModules()
+// + re-require) before asserting against a mutated config.
 const attributeConfigs = new Map(Object.entries(config.googlePerspective.attributes));
 
 // Custom error class to carry HTTP status from Perspective API

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.5.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1439,35 +1439,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@commitlint/read/node_modules/git-raw-commits": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "security:check": "npm audit --audit-level=high",
     "security:osv": "scripts/maybe-run.sh osv-scanner 'brew install osv-scanner' --lockfile=package-lock.json",
     "security:semgrep": "scripts/maybe-run.sh semgrep 'brew install semgrep (or pip install semgrep)' --config=p/javascript --config=p/nodejsscan --config=p/owasp-top-ten --error --metrics=off",
-    "security:secrets": "scripts/maybe-run.sh gitleaks 'brew install gitleaks' detect --no-banner",
-    "security:licenses": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
+    "security:secrets": "scripts/maybe-run.sh gitleaks 'brew install gitleaks' detect --no-banner --redact",
+    "security:licenses": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "security:all": "run-s security:check security:osv security:semgrep security:secrets security:licenses",
     "deploy": "serverless deploy",
     "deploy:prod": "serverless deploy --stage prod",
@@ -65,7 +65,7 @@
     "serverless-http": "^4.0.0"
   },
   "overrides": {
-    "fast-xml-parser": "^5.7.0"
+    "fast-xml-parser": "5.7.1"
   },
   "devDependencies": {
     "@commitlint/cli": "20.5.0",

--- a/scripts/maybe-run.sh
+++ b/scripts/maybe-run.sh
@@ -10,7 +10,15 @@
 #
 # Exits with the tool's exit code when it runs, or 0 when skipped.
 
-set -e
+set -eu
+
+# Guard against a mis-wired call (fewer than 2 args), which would otherwise
+# slip past `shift 2` and print a misleading "<hint> not installed" message
+# while exiting 0.
+if [ "$#" -lt 2 ]; then
+  echo "usage: maybe-run.sh <tool> <install-hint> [args...]" >&2
+  exit 2
+fi
 
 tool="$1"
 hint="$2"


### PR DESCRIPTION
Consolidated non-blocking minors from review of #33, #35, #36:

- **maybe-run.sh** — `set -eu` + arg-count guard so a mis-wired call (<2 args) fails loudly (exit 2) instead of a misleading hint.
- **security:secrets** — add `--redact` so found secrets aren't printed to logs. _(superseded by #37, which swaps the scanner entirely.)_
- **security:licenses** — drop unused `Python-2.0`/`WTFPL` from the allowlist.
- **overrides** — pin `fast-xml-parser` to exact `5.7.1` (consistent with `save-exact=true`).
- **perspective.js** — note the lookup `Map` is built once at module load (tests mutating config must reset modules).
- **CHANGELOG** — Security note for the fast-xml-parser CVE closure.

Closes #41

---
_Stacked on #40. Merge order: #38 → #39 → #40 → **#41** → #37._
