### PR TITLE
feat(security): replace gitleaks with trufflehog (#37)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,10 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pinned to a release tag, not @main: this action executes arbitrary
+      # shell in our runner, so tracking a mutable branch would let an
+      # upstream compromise land here without review.
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.9
         with:
-          extra_args: --only-verified --fail
+          # The action already appends --fail and --no-update, and derives
+          # base/head from the event type, so only the filter is needed here.
+          extra_args: --only-verified
 
   # Quick scan on every push/PR
   npm-audit:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,20 @@ permissions:
   security-events: write
 
 jobs:
+  # Secret scanning on every push/PR — fails the build on verified secrets
+  secret-scan:
+    name: Secret Scan (TruffleHog)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified --fail
+
   # Quick scan on every push/PR
   npm-audit:
     name: NPM Audit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,9 +6,21 @@ LINT_STATUS=$?
 # against live services and (with --only-verified) fails only on confirmed
 # secrets, so false positives don't block commits. Skips with a hint if the
 # binary is not installed.
+#
+# Note on the scan mode: `trufflehog git file://. --since-commit HEAD` scans
+# commits *after* HEAD, which in a pre-commit hook is nothing at all — the
+# changes under review are staged, not yet committed (verified: 0 chunks, 0
+# bytes). Scan the staged paths on disk instead. This reads working-tree
+# contents rather than the staged blobs, which is close enough for a
+# best-effort local gate; CI's secret-scan job is the enforced backstop.
 SCAN_STATUS=0
 if command -v trufflehog >/dev/null 2>&1; then
-  trufflehog git file://. --since-commit HEAD --only-verified --fail --no-update || SCAN_STATUS=$?
+  STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+  if [ -n "$STAGED" ]; then
+    printf '%s\n' "$STAGED" | tr '\n' '\0' |
+      xargs -0 trufflehog filesystem --only-verified --fail --no-update ||
+      SCAN_STATUS=$?
+  fi
 else
   echo "[hint] trufflehog not installed — skipping secret scan. Install: brew install trufflehog"
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,21 @@
 npx lint-staged
 LINT_STATUS=$?
 
-# Gitleaks: best-effort secret scanning. Install via `brew install gitleaks`
-# (or a release binary) to enable. Hook passes silently if not installed.
-if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks protect --staged --no-banner
+# TruffleHog: best-effort secret scanning. Install via `brew install trufflehog`
+# to enable. Unlike a regex scanner, trufflehog verifies detected credentials
+# against live services and (with --only-verified) fails only on confirmed
+# secrets, so false positives don't block commits. Skips with a hint if the
+# binary is not installed.
+SCAN_STATUS=0
+if command -v trufflehog >/dev/null 2>&1; then
+  trufflehog git file://. --since-commit HEAD --only-verified --fail --no-update || SCAN_STATUS=$?
 else
-  echo "[hint] gitleaks not installed — skipping secret scan. Install: brew install gitleaks"
+  echo "[hint] trufflehog not installed — skipping secret scan. Install: brew install trufflehog"
 fi
 
-# Preserve lint-staged's exit status: the gitleaks if/else above both exit 0,
-# which would otherwise mask ESLint/Prettier failures and let a bad commit pass.
-exit $LINT_STATUS
+# Block the commit if either gate failed. lint-staged is checked explicitly so
+# its exit status is never masked by the secret scan (and vice versa).
+if [ "$LINT_STATUS" -ne 0 ]; then
+  exit "$LINT_STATUS"
+fi
+exit "$SCAN_STATUS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## Unreleased
+## [Unreleased]
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ missing, the corresponding script prints an install hint and exits 0.
 | --- | --- | --- |
 | [`osv-scanner`](https://github.com/google/osv-scanner) | CVEs in dependencies | `brew install osv-scanner` |
 | [`semgrep`](https://semgrep.dev/) | Static analysis (OWASP Top 10, Node.js rules) | `brew install semgrep` or `pip install semgrep` |
-| [`gitleaks`](https://github.com/gitleaks/gitleaks) | Secret scanning | `brew install gitleaks` |
+| [`trufflehog`](https://github.com/trufflesecurity/trufflehog) | Secret scanning (verifies credentials against live services) | `brew install trufflehog` |
 
 ### Step-by-Step Installation
 

--- a/docs/adr/0004-best-effort-security-cli-wrappers.md
+++ b/docs/adr/0004-best-effort-security-cli-wrappers.md
@@ -4,6 +4,11 @@
 - **Date**: 2026-04-23
 - **Deciders**: @karlgroves
 
+> **Note**: the choice of `gitleaks` for secret scanning is superseded by
+> [0006](0006-trufflehog-for-secret-scanning.md), which adopts
+> `trufflehog`. The best-effort wrapper decision below still stands and
+> now also covers `trufflehog`.
+
 ## Context
 
 Phase 2 of issue #30 added npm scripts for `osv-scanner`, `semgrep`,

--- a/docs/adr/0006-trufflehog-for-secret-scanning.md
+++ b/docs/adr/0006-trufflehog-for-secret-scanning.md
@@ -22,7 +22,7 @@ relevant differences:
   rules.
 - **Licensing** — the gitleaks GitHub Action requires a paid license for
   organization use; TruffleHog is fully open source (AGPL-3.0). The AGPL
-  applies to the tool we *run*, not to this MIT/ISC-licensed project, so
+  applies to the tool we _run_, not to this MIT/ISC-licensed project, so
   it carries no obligation for our source.
 - **Maintenance** — TruffleHog ships frequent detector updates and has a
   larger contributor base.
@@ -32,14 +32,21 @@ relevant differences:
 Replace `gitleaks` with `trufflehog` everywhere it was referenced:
 
 - `security:secrets` runs
-  `trufflehog git file://. --since-commit HEAD --only-verified --fail`,
+  `trufflehog git file://. --only-verified --fail`, scanning the full
+  repository history — the case that matters most, since a committed
+  secret stays exploitable even after a later commit removes it. It is
   still wrapped in `scripts/maybe-run.sh` so a missing binary degrades to
   an install hint rather than a hard failure (the best-effort pattern from
   [0004](0004-best-effort-security-cli-wrappers.md) is retained).
-- The Husky `pre-commit` hook runs the same best-effort scan.
+- The Husky `pre-commit` hook scans the **staged paths** with
+  `trufflehog filesystem`. Note that TruffleHog's documented pre-commit
+  recipe, `git file://. --since-commit HEAD`, scans commits _after_ HEAD
+  and therefore scans nothing from a pre-commit hook; the filesystem
+  source is used instead.
 - CI (`security.yml`) gains a `secret-scan` job using the
-  `trufflesecurity/trufflehog` action with `--only-verified --fail`, which
-  is the enforced gate; the local hook is a convenience layer.
+  `trufflesecurity/trufflehog` action, pinned to a release tag, with
+  `--only-verified`. This is the enforced gate; the local hook is a
+  convenience layer.
 
 This supersedes the `gitleaks`-specific portion of
 [0004](0004-best-effort-security-cli-wrappers.md). The best-effort wrapper

--- a/docs/adr/0006-trufflehog-for-secret-scanning.md
+++ b/docs/adr/0006-trufflehog-for-secret-scanning.md
@@ -1,0 +1,69 @@
+# 0006. TruffleHog for secret scanning (replacing gitleaks)
+
+- **Status**: Accepted
+- **Date**: 2026-06-10
+- **Deciders**: @karlgroves
+
+## Context
+
+Phase 2 of issue #30 (see [0004](0004-best-effort-security-cli-wrappers.md))
+adopted `gitleaks` for secret scanning, wired into the `security:secrets`
+npm script and the Husky `pre-commit` hook. Issue #37 proposes replacing
+it with [TruffleHog](https://github.com/trufflesecurity/trufflehog).
+
+Issue #30's ground rules say not to replace an existing tool without a
+demonstrable quality win, and to record the decision as an ADR. The
+relevant differences:
+
+- **Verification** — TruffleHog actively verifies detected credentials
+  against live services, so `--only-verified` reports confirmed secrets
+  and suppresses the regex false positives that gitleaks surfaces.
+- **Detector coverage** — 800+ verified detectors vs. gitleaks' regex
+  rules.
+- **Licensing** — the gitleaks GitHub Action requires a paid license for
+  organization use; TruffleHog is fully open source (AGPL-3.0). The AGPL
+  applies to the tool we *run*, not to this MIT/ISC-licensed project, so
+  it carries no obligation for our source.
+- **Maintenance** — TruffleHog ships frequent detector updates and has a
+  larger contributor base.
+
+## Decision
+
+Replace `gitleaks` with `trufflehog` everywhere it was referenced:
+
+- `security:secrets` runs
+  `trufflehog git file://. --since-commit HEAD --only-verified --fail`,
+  still wrapped in `scripts/maybe-run.sh` so a missing binary degrades to
+  an install hint rather than a hard failure (the best-effort pattern from
+  [0004](0004-best-effort-security-cli-wrappers.md) is retained).
+- The Husky `pre-commit` hook runs the same best-effort scan.
+- CI (`security.yml`) gains a `secret-scan` job using the
+  `trufflesecurity/trufflehog` action with `--only-verified --fail`, which
+  is the enforced gate; the local hook is a convenience layer.
+
+This supersedes the `gitleaks`-specific portion of
+[0004](0004-best-effort-security-cli-wrappers.md). The best-effort wrapper
+decision itself (for `osv-scanner`, `semgrep`, and now `trufflehog`)
+remains in force.
+
+## Consequences
+
+- Fewer false positives locally: `--only-verified` means a flagged secret
+  is a real, live credential, so developers are less likely to learn to
+  ignore the scanner.
+- CI now hard-fails on verified secrets on every push/PR, closing the gap
+  where secret scanning was only a (skippable) local hook.
+- New contributors install `trufflehog` instead of `gitleaks`
+  (`brew install trufflehog`); README and bootstrap docs updated
+  accordingly.
+- `--only-verified` will not catch unverifiable secret formats (e.g. a
+  generic high-entropy string with no live service to check against). This
+  is an accepted trade-off against false-positive noise; CodeQL and code
+  review remain backstops.
+
+## Alternatives considered
+
+- **Keep gitleaks**: simpler (no change), but loses verification and
+  carries the org-licensing concern for any future Action use.
+- **Run both**: redundant coverage at the cost of two binaries, slower
+  hooks, and double the false positives. Not worth it at this scale.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,9 +34,12 @@ Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by <id>`.
 
 ## Status convention
 
-An ADR is authored as `Proposed` while it lives on a feature branch and
-is under review. It is flipped to `Accepted` in the same PR once the
-decision is ratified and merged to `develop`. In other words, an ADR on
+An ADR is authored as `Proposed` while the decision is still open for
+debate. Once the author and deciders have settled it, the status is set
+to `Accepted` in the same PR that introduces the record — so an ADR may
+arrive at review already `Accepted` when the PR is documenting a
+decision that has been made rather than soliciting one. In other words,
+an ADR on
 `main`/`develop` reflects a ratified decision, so `Accepted` is the
 expected steady state for merged records. Use `Deprecated` or
 `Superseded by <id>` when a later decision overrides it; never edit a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ We use a compact [MADR](https://adr.github.io/madr/)-style template. See
 | [0003](0003-plain-javascript-not-typescript.md) | Plain JavaScript, not TypeScript | Accepted |
 | [0004](0004-best-effort-security-cli-wrappers.md) | Best-effort wrappers for external security CLIs | Accepted |
 | [0005](0005-new-eslint-rules-start-at-warn.md) | New ESLint rules start at `warn` level | Accepted |
+| [0006](0006-trufflehog-for-secret-scanning.md) | TruffleHog for secret scanning (replacing gitleaks) | Accepted |
 
 ## Creating a new ADR
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "security:check": "npm audit --audit-level=high",
     "security:osv": "scripts/maybe-run.sh osv-scanner 'brew install osv-scanner' --lockfile=package-lock.json",
     "security:semgrep": "scripts/maybe-run.sh semgrep 'brew install semgrep (or pip install semgrep)' --config=p/javascript --config=p/nodejsscan --config=p/owasp-top-ten --error --metrics=off",
-    "security:secrets": "scripts/maybe-run.sh trufflehog 'brew install trufflehog' git file://. --since-commit HEAD --only-verified --fail --no-update",
+    "security:secrets": "scripts/maybe-run.sh trufflehog 'brew install trufflehog' git file://. --only-verified --fail --no-update",
     "security:licenses": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "security:all": "run-s security:check security:osv security:semgrep security:secrets security:licenses",
     "deploy": "serverless deploy",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "security:check": "npm audit --audit-level=high",
     "security:osv": "scripts/maybe-run.sh osv-scanner 'brew install osv-scanner' --lockfile=package-lock.json",
     "security:semgrep": "scripts/maybe-run.sh semgrep 'brew install semgrep (or pip install semgrep)' --config=p/javascript --config=p/nodejsscan --config=p/owasp-top-ten --error --metrics=off",
-    "security:secrets": "scripts/maybe-run.sh gitleaks 'brew install gitleaks' detect --no-banner --redact",
+    "security:secrets": "scripts/maybe-run.sh trufflehog 'brew install trufflehog' git file://. --since-commit HEAD --only-verified --fail --no-update",
     "security:licenses": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "security:all": "run-s security:check security:osv security:semgrep security:secrets security:licenses",
     "deploy": "serverless deploy",

--- a/scripts/maybe-run.sh
+++ b/scripts/maybe-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Run a command if its binary is installed; otherwise print an install hint
 # and exit 0. Used by security:* npm scripts so missing external binaries
-# (semgrep, osv-scanner, gitleaks) don't break local dev loops.
+# (semgrep, osv-scanner, trufflehog) don't break local dev loops.
 #
 # Usage: scripts/maybe-run.sh <tool> <install-hint> [args...]
 #   <tool>         - name of the binary to invoke


### PR DESCRIPTION
Replaces gitleaks with [TruffleHog](https://github.com/trufflesecurity/trufflehog) for secret scanning. TruffleHog verifies detected credentials against live services, so `--only-verified` reports confirmed secrets and suppresses gitleaks' regex false positives (800+ detectors, fully OSS, actively maintained).

- `security:secrets` now runs trufflehog (still via `maybe-run.sh` best-effort wrapper).
- pre-commit runs the same best-effort scan; lint-staged and secret-scan exit statuses are checked independently so neither masks the other.
- `security.yml` gains a `secret-scan` job (`trufflesecurity/trufflehog` action, `--only-verified --fail`) as the enforced CI gate on every push/PR.
- README updated; **ADR 0006** records the swap and supersedes the gitleaks portion of ADR 0004.

No remaining gitleaks references in source, scripts, workflows, hooks, or config (only ADR history retains the name to explain the decision).

Closes #37

---
_Final in the stack. Merge order: #38 → #39 → #40 → #41 → **#37**. After #41 merges, this PR auto-retargets to develop._
