### PR TITLE
chore(lint): make the CI lint gate green

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -9,7 +9,8 @@
     "**/*.min.js",
     "**/*.min.css",
     "**/package-lock.json",
-    "**/yarn.lock"
+    "**/yarn.lock",
+    "**/*.postman_collection.json"
   ],
   "gitignore": true,
   "minLines": 5,

--- a/README.md
+++ b/README.md
@@ -188,11 +188,11 @@ Legacy endpoint maintained for backward compatibility. Automatically redirects t
 The `security:*` npm scripts below use external binaries. If a binary is
 missing, the corresponding script prints an install hint and exits 0.
 
-| Tool | Purpose | Install |
-| --- | --- | --- |
-| [`osv-scanner`](https://github.com/google/osv-scanner) | CVEs in dependencies | `brew install osv-scanner` |
-| [`semgrep`](https://semgrep.dev/) | Static analysis (OWASP Top 10, Node.js rules) | `brew install semgrep` or `pip install semgrep` |
-| [`trufflehog`](https://github.com/trufflesecurity/trufflehog) | Secret scanning (verifies credentials against live services) | `brew install trufflehog` |
+| Tool                                                          | Purpose                                                      | Install                                         |
+| ------------------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------- |
+| [`osv-scanner`](https://github.com/google/osv-scanner)        | CVEs in dependencies                                         | `brew install osv-scanner`                      |
+| [`semgrep`](https://semgrep.dev/)                             | Static analysis (OWASP Top 10, Node.js rules)                | `brew install semgrep` or `pip install semgrep` |
+| [`trufflehog`](https://github.com/trufflesecurity/trufflehog) | Secret scanning (verifies credentials against live services) | `brew install trufflehog`                       |
 
 ### Step-by-Step Installation
 

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -8,7 +8,7 @@
 
 What is the issue we're facing? What constraints apply (technical,
 organizational, legal)? Keep this section factual; save opinions for
-*Decision*.
+_Decision_.
 
 ## Decision
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -22,7 +22,7 @@ changes, we write a new ADR that supersedes the old one rather than
 editing history.
 
 Scope: decisions about tooling, architecture, process, and
-dependencies. *Not* bug fixes, day-to-day implementation, or code style.
+dependencies. _Not_ bug fixes, day-to-day implementation, or code style.
 
 ## Consequences
 

--- a/docs/adr/0004-best-effort-security-cli-wrappers.md
+++ b/docs/adr/0004-best-effort-security-cli-wrappers.md
@@ -44,7 +44,7 @@ The pre-commit hook already uses the same best-effort pattern for
 - CI jobs that need a hard gate must explicitly install the binaries
   before running the scripts. Best-effort behavior is a local-dev
   convenience, not a substitute for enforced CI.
-- If a developer *thinks* they are running a security scan but the
+- If a developer _thinks_ they are running a security scan but the
   binary is silently missing, they get the install hint — not a silent
   pass. The hint is easy to miss in long output; documentation
   (README + this ADR) has to carry the load.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,7 +3,7 @@
 This directory contains Architecture Decision Records (ADRs) — short
 documents capturing a single significant decision along with the context
 and consequences. They exist so that future contributors (human or
-agent) can understand *why* a choice was made, not just *what* the code
+agent) can understand _why_ a choice was made, not just _what_ the code
 does today.
 
 ## Format
@@ -13,14 +13,14 @@ We use a compact [MADR](https://adr.github.io/madr/)-style template. See
 
 ## Index
 
-| # | Title | Status |
-| --- | --- | --- |
-| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](0002-keep-jest-as-test-runner.md) | Keep Jest as the test runner | Accepted |
-| [0003](0003-plain-javascript-not-typescript.md) | Plain JavaScript, not TypeScript | Accepted |
-| [0004](0004-best-effort-security-cli-wrappers.md) | Best-effort wrappers for external security CLIs | Accepted |
-| [0005](0005-new-eslint-rules-start-at-warn.md) | New ESLint rules start at `warn` level | Accepted |
-| [0006](0006-trufflehog-for-secret-scanning.md) | TruffleHog for secret scanning (replacing gitleaks) | Accepted |
+| #                                                 | Title                                               | Status   |
+| ------------------------------------------------- | --------------------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md)     | Record architecture decisions                       | Accepted |
+| [0002](0002-keep-jest-as-test-runner.md)          | Keep Jest as the test runner                        | Accepted |
+| [0003](0003-plain-javascript-not-typescript.md)   | Plain JavaScript, not TypeScript                    | Accepted |
+| [0004](0004-best-effort-security-cli-wrappers.md) | Best-effort wrappers for external security CLIs     | Accepted |
+| [0005](0005-new-eslint-rules-start-at-warn.md)    | New ESLint rules start at `warn` level              | Accepted |
+| [0006](0006-trufflehog-for-secret-scanning.md)    | TruffleHog for secret scanning (replacing gitleaks) | Accepted |
 
 ## Creating a new ADR
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,10 @@ export default [
       'unicorn/prefer-module': 'off',
       'unicorn/prefer-top-level-await': 'off',
 
-      'no-secrets/no-secrets': ['error', { tolerance: 4.5, ignoreContent: ['https?://', 'data:image/'] }],
+      'no-secrets/no-secrets': [
+        'error',
+        { tolerance: 4.5, ignoreContent: ['https?://', 'data:image/'] },
+      ],
 
       'jsdoc/check-tag-names': 'error',
       'jsdoc/check-alignment': 'error',


### PR DESCRIPTION
The `lint` job in `ci.yml` has been failing on `develop` independently of
any recent feature work. This fixes both causes.

## `format:check`

Six files predating this change were never prettier-formatted. Applied
`prettier --write`. The diff is purely cosmetic — line wrapping and
markdown table padding.

The only config file touched is `eslint.config.mjs`, where a single rule
object was re-wrapped across lines. `npm run lint` reports the identical
**14 warnings / 0 errors** before and after, confirming no semantic
change to the rule set.

## `lint:cpd:ci`

jscpd reported **7.83%** duplication against a 5% threshold. All 8 JSON
clones came from `content-moderation-api.postman_collection.json` — a
Postman export, where repeated request blocks are inherent to the format
and duplication analysis is meaningless.

Excluded `*.postman_collection.json` from jscpd. The remaining figure is
**3.67%**, all JavaScript, comfortably under threshold. **No threshold
was loosened** and no JavaScript duplication was hidden.

## Verification

| Check | Result |
| --- | --- |
| `npm run lint` | exit 0 (14 warnings, 0 errors — unchanged) |
| `npm run format:check` | exit 0 |
| `npm run lint:md` | exit 0 |
| `npm run lint:cpd:ci` | exit 0 (3.67% < 5%) |
| `npm test` | 85/85 pass |

https://claude.ai/code/session_0178sRjrHABk3fFC2xT2xsQ7