### PR TITLE
chore(npm): mark package private to prevent accidental publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openai-content-moderator",
   "version": "1.0.0",
+  "private": true,
   "description": "Middleware-based REST API for content moderation using OpenAI",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Mechanical npm publish-configuration change, part of a fleet-wide sweep.

- Removes the deprecated `always-auth` setting (npm 11 reports it as an unknown project config and ignores it).

- Makes publish visibility explicit so a bare `npm publish` is correct and cannot be flipped public by a stray `--access public`.