### PR TITLE
fix(middleware): bound upstream calls and keep credentials out of URLs and logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,17 @@
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=omni-moderation-latest
+# Upstream request budget. Sized against the 30s Lambda timeout in
+# serverless.yml; the SDK default is a 10-minute timeout with 2 retries.
+OPENAI_TIMEOUT_MS=8000
+OPENAI_MAX_RETRIES=1
 
 # Google Perspective API Configuration
 GOOGLE_PERSPECTIVE_API_KEY=your-google-perspective-api-key-here
 PERSPECTIVE_API_ENABLED=true
+# Perspective is optional enrichment and never fails the request, so it gets a
+# smaller slice of the Lambda budget and no retries.
+PERSPECTIVE_TIMEOUT_MS=5000
 
 # API Authentication (optional - if set, clients must send x-api-key header)
 API_SECRET_KEY=

--- a/config/index.js
+++ b/config/index.js
@@ -6,15 +6,33 @@ module.exports = {
   },
 
   // OpenAI configuration
+  //
+  // Timeouts are sized against the 30s Lambda budget in serverless.yml. The SDK
+  // ships a 10-minute default timeout with 2 automatic retries -- 20x longer
+  // than the function is allowed to live -- so a slow upstream would burn the
+  // whole budget and hand the caller an API Gateway timeout instead of the
+  // handled 503 this code tries to produce.
+  //
+  // Worst case with the defaults below: Perspective 5s, then OpenAI 2 attempts
+  // at 8s = 16s, for ~21s inside a 30s budget.
   openai: {
     apiKey: process.env.OPENAI_API_KEY,
     model: process.env.OPENAI_MODEL || 'omni-moderation-latest',
+    timeoutMs: Number(process.env.OPENAI_TIMEOUT_MS) || 8000,
+    // Not `||`: 0 is a meaningful value and must not fall through to the default.
+    maxRetries: Number.isFinite(Number(process.env.OPENAI_MAX_RETRIES))
+      ? Number(process.env.OPENAI_MAX_RETRIES)
+      : 1,
   },
 
   // Google Perspective API configuration
   googlePerspective: {
     apiKey: process.env.GOOGLE_PERSPECTIVE_API_KEY,
     enabled: process.env.PERSPECTIVE_API_ENABLED === 'true',
+    // Perspective is optional enrichment, so it gets the smaller slice of the
+    // Lambda budget and no retries: a slow Perspective must never be the
+    // reason the primary OpenAI moderation does not happen.
+    timeoutMs: Number(process.env.PERSPECTIVE_TIMEOUT_MS) || 5000,
     discoveryUrl: 'https://commentanalyzer.googleapis.com/$discovery/rest?version=v1alpha1',
     attributes: {
       TOXICITY: { scoreThreshold: 0.7 },
@@ -37,7 +55,8 @@ module.exports = {
     credentials: true,
   },
 
-  // Rate limiting configuration (for future implementation)
+  // Rate limiting configuration. This is the authoritative source: app.js reads
+  // these values when constructing the express-rate-limit middleware.
   rateLimit: {
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100, // limit each IP to 100 requests per windowMs

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,6 +1,15 @@
 // Global error handling middleware
 const errorHandler = (err, req, res, next) => {
-  console.error('Error:', err);
+  // Log an explicit, allowlisted shape rather than the raw error object, which
+  // may carry an unbounded `cause` chain from a third-party client. The stack is
+  // kept because it is ours and is the useful part for debugging.
+  console.error('Error:', {
+    name: err?.name,
+    message: err?.message,
+    statusCode: err?.statusCode ?? err?.status,
+    code: err?.code,
+    stack: err?.stack,
+  });
 
   // Set appropriate status code
   const statusCode = err.statusCode || err.status || 500;

--- a/middleware/moderation.js
+++ b/middleware/moderation.js
@@ -1,9 +1,31 @@
 const OpenAI = require('openai');
 const config = require('../config');
 
-// Initialize OpenAI client
+// Initialize OpenAI client.
+//
+// timeout and maxRetries are set explicitly rather than inherited: the SDK
+// defaults to a 10-minute timeout with 2 retries, which is 20x the 30s Lambda
+// budget in serverless.yml. A slow response under the defaults burns the whole
+// budget and the caller gets an API Gateway timeout instead of the handled 503
+// the catch block below is trying to produce. See config/index.js for the
+// budget arithmetic.
 const openai = new OpenAI({
   apiKey: config.openai.apiKey,
+  timeout: config.openai.timeoutMs,
+  maxRetries: config.openai.maxRetries,
+});
+
+// Reduce an error to an explicit, allowlisted shape before logging, rather than
+// handing the whole object to console.error. Deliberately not shared with
+// middleware/perspective.js: a shared logging helper merges taint paths and
+// makes CodeQL strictly worse (see karlgroves/spyfu-client#27 and #60).
+const describeError = error => ({
+  name: error?.name,
+  message: error?.message,
+  status: error?.status,
+  code: error?.code,
+  type: error?.type,
+  request_id: error?.request_id,
 });
 
 // Moderation middleware that calls OpenAI API
@@ -29,7 +51,18 @@ const moderateContent = async (req, res, next) => {
 
     next();
   } catch (error) {
-    console.error('OpenAI Moderation API Error:', error);
+    console.error('OpenAI Moderation API Error:', describeError(error));
+
+    // A timeout or dropped connection is an upstream availability problem, not a
+    // bug in the caller's request: report it as 503 rather than a generic 500.
+    // These errors carry no `status`, so the checks below would miss them.
+    // Matched by instanceof because the SDK leaves `name` as plain 'Error';
+    // APIConnectionTimeoutError extends APIConnectionError, so both are covered.
+    if (error instanceof OpenAI.APIConnectionError) {
+      return res.status(503).json({
+        error: 'OpenAI service is temporarily unavailable. Please try again later.',
+      });
+    }
 
     // Handle specific OpenAI errors
     if (error.status === 401) {

--- a/middleware/perspective.js
+++ b/middleware/perspective.js
@@ -1,5 +1,11 @@
 const config = require('../config');
 
+const PERSPECTIVE_ENDPOINT = 'https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze';
+
+// Fallback used when a caller-supplied config omits the timeout (the unit tests
+// mock ../config wholesale, so the key is not always present).
+const DEFAULT_TIMEOUT_MS = 5000;
+
 // Lookup table built once at module load so we can use Map.get() for attribute
 // config instead of a computed property access on the plain config object.
 // NOTE: because this runs once when the module is first required, a test that
@@ -16,22 +22,41 @@ class PerspectiveApiError extends Error {
   }
 }
 
+// Reduce an error to an explicit, allowlisted shape before logging.
+//
+// Written inline in this module rather than shared with middleware/moderation.js
+// on purpose: a shared logging helper merges taint paths and makes CodeQL
+// strictly worse (see karlgroves/spyfu-client#27 and #60). A `fetch` rejection
+// carries a `cause` chain whose contents are undici's, not ours, so logging the
+// raw object is exactly what this avoids.
+const describeError = error => ({
+  name: error?.name,
+  message: error?.message,
+  statusCode: error?.statusCode,
+  code: error?.code ?? error?.cause?.code,
+});
+
 // Helper function to make API request to Perspective API
 const makePerspectiveRequest = async text => {
-  const url = `https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${config.googlePerspective.apiKey}`;
-
   const data = {
     comment: { text },
     requestedAttributes: config.googlePerspective.attributes,
     languages: ['en'],
   };
 
-  const response = await fetch(url, {
+  const response = await fetch(PERSPECTIVE_ENDPOINT, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      // The key travels in a header, not the query string. `?key=` is a
+      // documented Google auth mechanism, but a secret in a URL is a secret in
+      // every access log, proxy log and error string that handles the request.
+      'x-goog-api-key': config.googlePerspective.apiKey,
     },
     body: JSON.stringify(data),
+    // Without this the call has no timeout of any kind, against a 30s Lambda
+    // budget it shares with the primary OpenAI call.
+    signal: AbortSignal.timeout(config.googlePerspective.timeoutMs ?? DEFAULT_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -95,37 +120,26 @@ const moderateWithPerspective = async (req, res, next) => {
 
     next();
   } catch (error) {
-    console.error('Perspective API Error:', error);
+    // Perspective is optional enrichment. It must never fail the request it
+    // enriches: this middleware runs BEFORE the OpenAI moderation, so returning
+    // a terminal response here means the primary function of the service — the
+    // moderation result — is never produced at all. Previously a Perspective
+    // rate-limit returned 429 to the caller and no moderation was performed.
+    //
+    // Every failure now degrades gracefully and the reason is surfaced in
+    // req.perspectiveMetadata rather than in the HTTP status.
+    console.warn('Perspective API failed, continuing without it:', describeError(error));
 
-    // Handle specific Perspective API errors using status codes
-    if (error instanceof PerspectiveApiError) {
-      if (error.statusCode === 400) {
-        return res.status(400).json({
-          error: 'Invalid request format for Perspective API',
-        });
-      } else if (error.statusCode === 401 || error.statusCode === 403) {
-        return res.status(401).json({
-          error: 'Invalid API key. Please check your Google Perspective API key configuration.',
-        });
-      } else if (error.statusCode === 429) {
-        return res.status(429).json({
-          error: 'Rate limit exceeded for Perspective API. Please try again later.',
-        });
-      } else if (error.statusCode === 503 || error.statusCode === 502) {
-        return res.status(503).json({
-          error: 'Perspective API service is temporarily unavailable. Please try again later.',
-        });
-      }
-    }
+    const isApiError = error instanceof PerspectiveApiError;
+    const isTimeout = error?.name === 'TimeoutError' || error?.name === 'AbortError';
 
-    // If Perspective fails, log error but continue without it
-    console.warn('Perspective API failed, continuing without it:', error.message);
     req.perspectiveResults = null;
     req.perspectiveMetadata = {
       timestamp: new Date().toISOString(),
       textLength: req.body.text.length,
       service: 'google-perspective',
-      error: 'Service unavailable',
+      error: isTimeout ? 'Timed out' : 'Service unavailable',
+      ...(isApiError ? { statusCode: error.statusCode } : {}),
     };
 
     next();

--- a/tests/helpers/testHelpers.js
+++ b/tests/helpers/testHelpers.js
@@ -1,5 +1,12 @@
 const nock = require('nock');
 const { mockOpenAIResponse, mockFlaggedResponse } = require('../fixtures/mockData');
+const config = require('../../config');
+
+// The OpenAI client retries per config.openai.maxRetries, so a failing call is
+// attempted maxRetries + 1 times. Deriving it here keeps `scope.isDone()` a
+// genuine assertion that the client made exactly the configured number of
+// attempts, instead of a hardcoded 3 that silently rots when the budget changes.
+const EXPECTED_ATTEMPTS = config.openai.maxRetries + 1;
 
 // Helper to mock OpenAI API calls
 const mockOpenAISuccess = (text = 'test text', response = mockOpenAIResponse) => {
@@ -12,7 +19,7 @@ const mockOpenAIError = (
 ) => {
   return nock('https://api.openai.com')
     .post('/v1/moderations')
-    .times(3) // Handle retries
+    .times(EXPECTED_ATTEMPTS)
     .reply(statusCode, errorBody);
 };
 
@@ -28,7 +35,7 @@ const mockOpenAISpecificError = (statusCode, message) => {
 
   return nock('https://api.openai.com')
     .post('/v1/moderations')
-    .times(3) // Handle retries
+    .times(EXPECTED_ATTEMPTS)
     .reply(statusCode, errorResponse);
 };
 
@@ -63,6 +70,7 @@ const createExpectedMetadata = (textLength, model = 'omni-moderation-latest') =>
 const waitFor = (ms = 100) => new Promise(resolve => setTimeout(resolve, ms));
 
 module.exports = {
+  EXPECTED_ATTEMPTS,
   mockOpenAISuccess,
   mockOpenAIError,
   mockOpenAISpecificError,

--- a/tests/unit/errorHandler.test.js
+++ b/tests/unit/errorHandler.test.js
@@ -27,7 +27,27 @@ describe('Error Handler Middleware', () => {
       expect(res.json).toHaveBeenCalledWith({
         error: 'Internal server error',
       });
-      expect(console.error).toHaveBeenCalledWith('Error:', error);
+      expect(console.error).toHaveBeenCalledWith('Error:', {
+        name: 'Error',
+        message: 'Test error',
+        statusCode: undefined,
+        code: undefined,
+        stack: error.stack,
+      });
+    });
+
+    // Regression test for #56: the raw error object may carry an unbounded
+    // `cause` chain from a third-party client, so only an allowlisted shape is
+    // logged.
+    it('logs an allowlisted shape rather than the raw error object', () => {
+      const error = new Error('Upstream failed');
+      error.cause = { authorization: 'Bearer super-secret-token' };
+
+      errorHandler(error, req, res, next);
+
+      const logged = console.error.mock.calls[0][1];
+      expect(logged).not.toHaveProperty('cause');
+      expect(JSON.stringify(logged)).not.toContain('super-secret-token');
     });
 
     it('should use error status code when provided', () => {

--- a/tests/unit/moderation.test.js
+++ b/tests/unit/moderation.test.js
@@ -1,6 +1,7 @@
 const nock = require('nock');
 const { moderateContent } = require('../../middleware/moderation');
 const {
+  EXPECTED_ATTEMPTS,
   mockOpenAISuccess,
   mockOpenAIFlagged,
   mockOpenAIError,
@@ -179,6 +180,54 @@ describe('Moderation Middleware - Core Functionality', () => {
         error: 'Failed to process moderation request',
       });
       expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regression tests for #57.
+  describe('Upstream resilience', () => {
+    it('bounds the client budget well inside the 30s Lambda timeout', () => {
+      const config = require('../../config');
+      const attempts = config.openai.maxRetries + 1;
+      const worstCaseMs = config.openai.timeoutMs * attempts + config.googlePerspective.timeoutMs;
+
+      // serverless.yml sets `timeout: 30`. The SDK default -- a 10 minute
+      // timeout with 2 retries -- is 20x the function's entire lifetime.
+      expect(config.openai.timeoutMs).toBeLessThanOrEqual(10000);
+      expect(worstCaseMs).toBeLessThan(30000);
+    });
+
+    it('reports an upstream connection failure as 503, not a generic 500', async () => {
+      req.body = { text: 'Test text' };
+
+      const scope = nock('https://api.openai.com')
+        .post('/v1/moderations')
+        .times(EXPECTED_ATTEMPTS)
+        .replyWithError({ code: 'ECONNRESET', message: 'socket hang up' });
+
+      await moderateContent(req, res, next);
+
+      expect(scope.isDone()).toBe(true);
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'OpenAI service is temporarily unavailable. Please try again later.',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('logs an allowlisted error shape, not the raw error object', async () => {
+      req.body = { text: 'Test text' };
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockOpenAIError(429, { error: { message: 'Rate limit exceeded' } });
+      await moderateContent(req, res, next);
+
+      const [label, logged] = console.error.mock.calls[0];
+      expect(label).toBe('OpenAI Moderation API Error:');
+      expect(Object.keys(logged).sort()).toEqual(
+        ['code', 'message', 'name', 'request_id', 'status', 'type'].sort()
+      );
+      expect(logged).not.toHaveProperty('headers');
+      console.error.mockRestore();
     });
   });
 });

--- a/tests/unit/perspective.test.js
+++ b/tests/unit/perspective.test.js
@@ -9,6 +9,7 @@ jest.mock('../../config', () => ({
   googlePerspective: {
     enabled: true,
     apiKey: 'test-api-key',
+    timeoutMs: 5000,
     attributes: {
       TOXICITY: { scoreThreshold: 0.7 },
       SEVERE_TOXICITY: { scoreThreshold: 0.7 },
@@ -19,6 +20,16 @@ jest.mock('../../config', () => ({
     },
   },
 }));
+
+const ENDPOINT = 'https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze';
+
+// Build a Perspective error response with the given HTTP status.
+const mockPerspectiveStatus = (status, message) =>
+  fetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: { message } }),
+  });
 
 describe('Perspective API Middleware', () => {
   let req, res, next;
@@ -37,6 +48,9 @@ describe('Perspective API Middleware', () => {
 
     // Reset fetch mock
     fetch.mockReset();
+
+    config.googlePerspective.enabled = true;
+    config.googlePerspective.apiKey = 'test-api-key';
 
     // Mock console methods
     jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -60,7 +74,6 @@ describe('Perspective API Middleware', () => {
     });
 
     it('should call next() when Perspective API key is missing', async () => {
-      config.googlePerspective.enabled = true;
       config.googlePerspective.apiKey = null;
 
       await moderateWithPerspective(req, res, next);
@@ -71,9 +84,6 @@ describe('Perspective API Middleware', () => {
     });
 
     it('should successfully process clean content', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
       const mockResponse = {
         attributeScores: {
           TOXICITY: {
@@ -105,11 +115,12 @@ describe('Perspective API Middleware', () => {
       await moderateWithPerspective(req, res, next);
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=test-api-key',
+        ENDPOINT,
         expect.objectContaining({
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'x-goog-api-key': 'test-api-key',
           },
           body: JSON.stringify({
             comment: { text: 'This is a test message' },
@@ -157,9 +168,6 @@ describe('Perspective API Middleware', () => {
     });
 
     it('should flag toxic content', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
       const mockResponse = {
         attributeScores: {
           TOXICITY: {
@@ -184,127 +192,10 @@ describe('Perspective API Middleware', () => {
       expect(next).toHaveBeenCalled();
     });
 
-    it('should handle 400 API errors', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        json: () =>
-          Promise.resolve({
-            error: { message: 'Bad request' },
-          }),
-      });
-
-      await moderateWithPerspective(req, res, next);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid request format for Perspective API',
-      });
-      expect(next).not.toHaveBeenCalled();
-    });
-
-    it('should handle 401 API errors', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-        json: () =>
-          Promise.resolve({
-            error: { message: 'Unauthorized' },
-          }),
-      });
-
-      await moderateWithPerspective(req, res, next);
-
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid API key. Please check your Google Perspective API key configuration.',
-      });
-      expect(next).not.toHaveBeenCalled();
-    });
-
-    it('should handle 429 rate limit errors', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 429,
-        json: () =>
-          Promise.resolve({
-            error: { message: 'Rate limit exceeded' },
-          }),
-      });
-
-      await moderateWithPerspective(req, res, next);
-
-      expect(res.status).toHaveBeenCalledWith(429);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Rate limit exceeded for Perspective API. Please try again later.',
-      });
-      expect(next).not.toHaveBeenCalled();
-    });
-
-    it('should handle 503 service unavailable errors', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 503,
-        json: () =>
-          Promise.resolve({
-            error: { message: 'Service unavailable' },
-          }),
-      });
-
-      await moderateWithPerspective(req, res, next);
-
-      expect(res.status).toHaveBeenCalledWith(503);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Perspective API service is temporarily unavailable. Please try again later.',
-      });
-      expect(next).not.toHaveBeenCalled();
-    });
-
-    it('should continue without Perspective API on other errors', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      fetch.mockRejectedValueOnce(new Error('Network error'));
-
-      await moderateWithPerspective(req, res, next);
-
-      expect(console.warn).toHaveBeenCalledWith(
-        'Perspective API failed, continuing without it:',
-        'Network error'
-      );
-
-      expect(req.perspectiveResults).toBe(null);
-      expect(req.perspectiveMetadata).toEqual({
-        timestamp: expect.any(String),
-        textLength: 22,
-        service: 'google-perspective',
-        error: 'Service unavailable',
-      });
-
-      expect(next).toHaveBeenCalled();
-    });
-
     it('should handle empty attributeScores response', async () => {
-      config.googlePerspective.enabled = true;
-      config.googlePerspective.apiKey = 'test-api-key';
-
-      const mockResponse = {};
-
       fetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockResponse),
+        json: () => Promise.resolve({}),
       });
 
       await moderateWithPerspective(req, res, next);
@@ -316,6 +207,121 @@ describe('Perspective API Middleware', () => {
         category_scores: {},
       });
 
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  // Regression tests for #56.
+  describe('credential handling', () => {
+    it('sends the API key in the x-goog-api-key header', async () => {
+      fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await moderateWithPerspective(req, res, next);
+
+      const [, options] = fetch.mock.calls[0];
+      expect(options.headers['x-goog-api-key']).toBe('test-api-key');
+    });
+
+    it('never puts the API key in the request URL', async () => {
+      fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await moderateWithPerspective(req, res, next);
+
+      const [url] = fetch.mock.calls[0];
+      // A secret in a URL is a secret in every access log and proxy log.
+      expect(url).toBe(ENDPOINT);
+      expect(url).not.toContain('test-api-key');
+      expect(url).not.toContain('key=');
+    });
+
+    it('logs an allowlisted error shape, not the raw error object', async () => {
+      const raw = new Error('Network error');
+      raw.cause = { secret: 'should-not-be-logged', code: 'ECONNRESET' };
+      fetch.mockRejectedValueOnce(raw);
+
+      await moderateWithPerspective(req, res, next);
+
+      expect(console.warn).toHaveBeenCalledWith('Perspective API failed, continuing without it:', {
+        name: 'Error',
+        message: 'Network error',
+        statusCode: undefined,
+        code: 'ECONNRESET',
+      });
+      const logged = JSON.stringify(console.warn.mock.calls[0][1]);
+      expect(logged).not.toContain('should-not-be-logged');
+    });
+  });
+
+  // Regression tests for #57.
+  describe('resilience', () => {
+    it('passes an abort signal so the call cannot hang', async () => {
+      fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await moderateWithPerspective(req, res, next);
+
+      const [, options] = fetch.mock.calls[0];
+      expect(options.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('degrades gracefully on timeout and records it in metadata', async () => {
+      const timeout = new Error('The operation was aborted due to timeout');
+      timeout.name = 'TimeoutError';
+      fetch.mockRejectedValueOnce(timeout);
+
+      await moderateWithPerspective(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+      expect(req.perspectiveResults).toBe(null);
+      expect(req.perspectiveMetadata).toEqual({
+        timestamp: expect.any(String),
+        textLength: 22,
+        service: 'google-perspective',
+        error: 'Timed out',
+      });
+    });
+
+    // Every one of these previously returned a terminal HTTP response, which
+    // meant an optional enrichment service could stop the primary OpenAI
+    // moderation from ever running.
+    it.each([
+      [400, 'Bad request'],
+      [401, 'Unauthorized'],
+      [403, 'Forbidden'],
+      [429, 'Rate limit exceeded'],
+      [500, 'Internal error'],
+      [502, 'Bad gateway'],
+      [503, 'Service unavailable'],
+    ])('degrades gracefully on upstream %i instead of failing the request', async (status, msg) => {
+      mockPerspectiveStatus(status, msg);
+
+      await moderateWithPerspective(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+      expect(req.perspectiveResults).toBe(null);
+      expect(req.perspectiveMetadata).toEqual({
+        timestamp: expect.any(String),
+        textLength: 22,
+        service: 'google-perspective',
+        error: 'Service unavailable',
+        statusCode: status,
+      });
+    });
+
+    it('continues without Perspective on a network error', async () => {
+      fetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await moderateWithPerspective(req, res, next);
+
+      expect(req.perspectiveResults).toBe(null);
+      expect(req.perspectiveMetadata).toEqual({
+        timestamp: expect.any(String),
+        textLength: 22,
+        service: 'google-perspective',
+        error: 'Service unavailable',
+      });
       expect(next).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Closes #56. Closes #57.

Both issues flagged runtime behaviour on a deployed service and asked for an ack
rather than a guess. Everything here is implemented as the issues recommended;
the notes below say what I decided where a value had to be chosen.

## #57.1 — no request timeout on either upstream call

`serverless.yml` gives the function **30s**.

| client | before | after |
| --- | --- | --- |
| OpenAI | no `timeout`, no `maxRetries` — SDK defaults to **10 min / 2 retries** | 8s, 1 retry |
| Perspective | `fetch` with **no `AbortSignal` at all** | `AbortSignal.timeout(5000)` |

Worst case is now Perspective 5s + OpenAI 2 attempts x 8s = **~21s inside a 30s
budget**. The budget arithmetic lives in `config/index.js` next to the values,
and all three are env-overridable (`OPENAI_TIMEOUT_MS`, `OPENAI_MAX_RETRIES`,
`PERSPECTIVE_TIMEOUT_MS`).

One thing the issue did not call out: connection and timeout errors carry no
`status`, so they fell through every branch to a generic **500**. They now map
to **503**. Matched with `instanceof OpenAI.APIConnectionError` — I probed the
SDK rather than assuming, and it leaves `name` as plain `'Error'`, so a
name-based check silently does nothing.

## #57.2 — Perspective could fail the request it enriches

Confirmed exactly as described: the catch block returned terminal responses for
400/401/403/429/502/503, and `moderateWithPerspective` runs **before**
`moderateContent`, so a Perspective rate-limit returned 429 and the OpenAI
moderation — the primary function of the service — never ran.

Every failure now degrades gracefully and the reason is surfaced in
`req.perspectiveMetadata` (`error`, plus `statusCode` for upstream HTTP errors),
which is what the issue suggested.

## #57.3 — rate-limit policy

The OpenAI retry policy is now deliberate (1) rather than an inherited default
(2). Also corrected the `config/index.js` comment claiming the `rateLimit` block
was "for future implementation" — it is the live source for the
`express-rate-limit` middleware in the app, which was the ambiguity the issue
asked to resolve.

## #56.1 — Perspective key in the URL query string

Moved to the `x-goog-api-key` header; the key no longer appears in the URL at
all. Two regression tests cover it, including one asserting the URL contains
neither the key nor `key=`.

## #56.2 — raw error objects logged

All three sites now log an explicit allowlisted shape instead of the whole
object. Built **inline in each module rather than shared** — a shared logging
helper merges taint paths and makes CodeQL strictly worse
(karlgroves/spyfu-client#27). `errorHandler.js` keeps `stack`, which is ours and
is the useful part.

## Verification

Mutation-verified rather than assumed — each of these turns the suite red:

| mutation | result |
| --- | --- |
| put `?key=` back in the Perspective URL | 2 failed |
| drop the `AbortSignal` | 1 failed |
| restore the terminal 429 from Perspective | 1 failed |
| log raw error objects again | 2 failed |
| revert to the SDK 10-minute default timeout | 1 failed |

`tests/helpers/testHelpers.js` previously hardcoded `.times(3) // Handle
retries`, silently encoding the SDK default — which is how the retry change
first showed up, as four `scope.isDone()` failures. It is now derived from
`config.openai.maxRetries`, making `scope.isDone()` a genuine assertion that the
client made exactly the configured number of attempts.

Suite goes **85 -> 97 tests**. All local gates green on Node 22.23.2: `lint`,
`format:check`, `lint:md`, `lint:cpd:ci`, `security:licenses`,
`npm audit --omit=dev --audit-level=high`, `check-no-scheduled-actions.sh`.
Husky pre-commit (lint-staged, TruffleHog) and commitlint ran on the commit.

## Note on ordering

Independent of #62 (Lambda entry point) — disjoint files, no conflict — but #62
is the one that unblocks deployment, so it is the more urgent of the two.

I have not archived this repository.
